### PR TITLE
Call test() instead of it()

### DIFF
--- a/src/PHPUnit/ClassMethod/MethodToPestTestRector.php
+++ b/src/PHPUnit/ClassMethod/MethodToPestTestRector.php
@@ -92,7 +92,7 @@ class MethodToPestTestRector extends AbstractClassMethodRector
     private function createPestTest($method): FuncCall
     {
         return $this->builderFactory->funcCall(
-            'it',
+            'test',
             [
                 $this->getName($method),
                 new Closure([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | -

<!--
- Replace this comment by a description of what your PR is solving.
-->

What:
--- 

Now calls the `test()` function instead of `it()`.

Why:
---

We don't want Pest to prefix every existing PHPUnit test titles with the word "it", so using `test()` is a safe default.

Before:
---

```
it can_view_password_request_page
it a_user_must_enter_an_email_address
```

After:
---

```
can_view_password_request_page
a_user_must_enter_an_email_address
```

