### PR TITLE
Fix broken tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
-        "symplify/easy-testing": "^8.1",
+        "symplify/easy-testing": "8.1.*",
         "symplify/easy-coding-standard": "^8.1",
         "phpstan/phpstan": "^0.12.36",
         "symplify/phpstan-extensions": "^8.1"

--- a/tests/fixtures/PHPUnit/ClassMethod/HelperMethodRector/phpunit_method_to_pest_helper_with_override_method.php.inc
+++ b/tests/fixtures/PHPUnit/ClassMethod/HelperMethodRector/phpunit_method_to_pest_helper_with_override_method.php.inc
@@ -1,4 +1,5 @@
 <?php
+namespace MethodOverride;
 use Pest\Drift\Testing\fixtures\CustomTestCase;
 
 class MethodOverrideTest extends CustomTestCase
@@ -21,6 +22,7 @@ class MethodOverrideTest extends CustomTestCase
 ?>
 -----
 <?php
+namespace MethodOverride;
 use Pest\Drift\Testing\fixtures\CustomTestCase;
 
 class MethodOverrideTest extends CustomTestCase
@@ -30,7 +32,7 @@ class MethodOverrideTest extends CustomTestCase
         return "Oliver";
     }
 }
-uses(MethodOverrideTest::class);
+uses(\MethodOverride\MethodOverrideTest::class);
 function alwaysTrueHelper()
 {
     test()->assertTrue(true);

--- a/tests/fixtures/PHPUnit/Class_/CustomTestCaseToUsesRector/phpunit_custom_test_case_to_pest_uses.php.inc
+++ b/tests/fixtures/PHPUnit/Class_/CustomTestCaseToUsesRector/phpunit_custom_test_case_to_pest_uses.php.inc
@@ -12,7 +12,7 @@ class CustomTestCaseTest extends CustomTestCase
 -----
 <?php
 use Pest\Drift\Testing\fixtures\CustomTestCase;
-uses(CustomTestCase::class);
+uses(\Pest\Drift\Testing\fixtures\CustomTestCase::class);
 test('testCustomTestCase', function () {
     $this->assertTrue(true);
 });


### PR DESCRIPTION
I have locked the easy-testing dependency that a change in v8.2 broke rectors base test class. 

We can change it later on when they have fixed it.