### PR TITLE
fix: update tests to work with latest rector

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -16,10 +16,10 @@ jobs:
 
                 actions:
                     -   name: Coding Standard
-                        run: 'composer check-cs'
+                        run: 'composer test:lint'
 
                     -   name: PHPStan
-                        run: 'composer phpstan'
+                        run: 'composer test:types'
 
                     -   name: Rector
                         run: 'composer rector'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,6 +28,11 @@ jobs:
                   php-version: ${{ matrix.php }}
                   extensions: ${{ env.extensions }}
 
+            - name: Setup problem matchers
+              run: |
+                echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+                echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
             - name: Get composer cache directory
               id: composer-cache
               run: echo "::set-output name=dir::$(composer config cache-files-dir)"
@@ -43,9 +48,3 @@ jobs:
 
             - name: Test with phpunit
               run: vendor/bin/phpunit
-
-            - name: Setup problem matchers for PHP
-              run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-
-            - name: Setup problem matchers for PHPUnit
-              run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/composer.json
+++ b/composer.json
@@ -38,13 +38,14 @@
     ],
     "scripts": {
         "lint": "vendor/bin/ecs check --fix --ansi",
-        "phpstan": "vendor/bin/phpstan analyze --ansi --error-format symplify",
         "rector": "vendor/bin/rector process --config rector-ci.php --ansi",
         "rector-dry": "vendor/bin/rector process --config rector-ci.php --ansi --dry-run",
         "test:lint": "vendor/bin/ecs check --ansi",
+        "test:types": "vendor/bin/phpstan analyze --ansi --memory-limit=0 --error-format symplify",
         "test:unit": "vendor/bin/phpunit --colors=always",
         "test": [
             "@test:lint",
+            "@test:types",
             "@test:unit"
         ]
     }

--- a/composer.json
+++ b/composer.json
@@ -37,10 +37,15 @@
         "bin/drift"
     ],
     "scripts": {
-        "check-cs": "vendor/bin/ecs check --ansi",
-        "fix-cs": "vendor/bin/ecs check --fix --ansi",
+        "lint": "vendor/bin/ecs check --fix --ansi",
         "phpstan": "vendor/bin/phpstan analyze --ansi --error-format symplify",
         "rector": "vendor/bin/rector process --config rector-ci.php --ansi",
-        "rector-dry": "vendor/bin/rector process --config rector-ci.php --ansi --dry-run"
+        "rector-dry": "vendor/bin/rector process --config rector-ci.php --ansi --dry-run",
+        "test:lint": "vendor/bin/ecs check --ansi",
+        "test:unit": "vendor/bin/phpunit --colors=always",
+        "test": [
+            "@test:lint",
+            "@test:unit"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
-        "symplify/easy-testing": "8.1.*",
-        "symplify/easy-coding-standard": "^8.1",
+        "symplify/easy-testing": "^8.2",
+        "symplify/easy-coding-standard": "^8.2",
         "phpstan/phpstan": "^0.12.36",
-        "symplify/phpstan-extensions": "^8.1"
+        "symplify/phpstan-extensions": "^8.2"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.4",
-        "rector/rector": "dev-master",
+        "rector/rector": "^0.8.6",
         "pestphp/pest": "^0.2"
     },
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.4",
-        "rector/rector": "^0.7.62",
+        "rector/rector": "dev-master",
         "pestphp/pest": "^0.2"
     },
     "authors": [

--- a/rector-ci.php
+++ b/rector-ci.php
@@ -20,9 +20,4 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::PATHS, [__DIR__ . '/src', __DIR__ . '/tests']);
 
     $parameters->set(Option::EXCLUDE_PATHS, [__DIR__ . '/tests/fixtures/*']);
-
-    $parameters->set(Option::EXCLUDE_RECTORS, [
-        // buggy, needs fix
-        \Rector\SOLID\Rector\ClassMethod\ChangeReadOnlyVariableWithDefaultValueToConstantRector::class,
-    ]);
 };

--- a/tests/Rectors/Polish/BasePolishRectorTest.php
+++ b/tests/Rectors/Polish/BasePolishRectorTest.php
@@ -5,7 +5,12 @@ declare(strict_types=1);
 namespace Pest\Drift\Testing\Rectors\Polish;
 
 use Pest\Drift\Testing\BaseRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
 
 abstract class BasePolishRectorTest extends BaseRectorTestCase
 {
+    protected function provideConfigFileInfo(): ?SmartFileInfo
+    {
+        return new SmartFileInfo(__DIR__ . '/../../config/polish_rectors.php');
+    }
 }

--- a/tests/config/phpunit_rectors.php
+++ b/tests/config/phpunit_rectors.php
@@ -5,5 +5,5 @@ declare(strict_types=1);
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import(__DIR__ . '/../../config/*');
+    $containerConfigurator->import(__DIR__ . '/../../config/phpunit-to-pest.php');
 };


### PR DESCRIPTION
When Rector 0.7.66 releases, we'll need to change the version selector in Composer. 👍🏻