### PR TITLE
Close markdown bold tags on WIP header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**WARNING: This is a 'work in progress'
+**WARNING: This is a 'work in progress'**
 
 
 <p align="center">


### PR DESCRIPTION
While scanning the repo (as Im having some issues installing drift with Pest 0.3.1) I noticed the bold tags weren't closed.